### PR TITLE
Allow any item to display shields

### DIFF
--- a/src/main/java/net/blay09/mods/clienttweaks/ClientTweaksConfig.java
+++ b/src/main/java/net/blay09/mods/clienttweaks/ClientTweaksConfig.java
@@ -29,6 +29,7 @@ public class ClientTweaksConfig {
         public final ForgeConfigSpec.ConfigValue<List<? extends String>> torchItems;
         public final ForgeConfigSpec.ConfigValue<List<? extends String>> torchTools;
         public final ForgeConfigSpec.ConfigValue<List<? extends String>> offhandTorchTools;
+        public final ForgeConfigSpec.ConfigValue<List<? extends String>> shieldWeapons;
 
         Client(ForgeConfigSpec.Builder builder) {
             builder.comment("Configuration for Client Tweaks").push("client");
@@ -122,6 +123,13 @@ public class ClientTweaksConfig {
                     .defineList("offhandTorchTools", Lists.newArrayList(
                             "tconstruct:shovel",
                             "tconstruct:excavator"), it -> it instanceof String);
+
+            shieldWeapons = builder
+                    .comment("Items that count as weapons for the offhand-shield hiding tweak options.")
+                    .translation("clienttweaks.config.shieldWeapons")
+                    .defineList("shieldWeapons", Lists.newArrayList(
+                            "tetra:modular_sword"
+                    ), it -> it instanceof String);
         }
     }
 

--- a/src/main/java/net/blay09/mods/clienttweaks/tweak/HideShieldUnlessHoldingWeapon.java
+++ b/src/main/java/net/blay09/mods/clienttweaks/tweak/HideShieldUnlessHoldingWeapon.java
@@ -47,6 +47,10 @@ public class HideShieldUnlessHoldingWeapon extends AbstractClientTweak {
             return;
         }
 
+        if (ClientTweaksConfig.CLIENT.shieldWeapons.get().contains(mainItem.getItem().getRegistryName().toString())) {
+            return;
+        }
+
         event.setCanceled(true);
     }
 


### PR DESCRIPTION
After playing with the mod in a pack, I noticed something annoying. Shields would display totally fine when I was holding any ordinary sword, but when I held one of Tetra's modular swords, it disappeared. After taking a look at the code, I decided this could be easy enough to fix. This uses the same system used for determining whether torches should be placed if a tool is held in hand.

- Allow users to define their own "weapons" in the config, so shields will display when these items are held too

- Add tetra modular swords as a default item