### PR TITLE
Add NoOffhandTorchAtAll

### DIFF
--- a/src/main/java/net/blay09/mods/clienttweaks/ClientTweaks.java
+++ b/src/main/java/net/blay09/mods/clienttweaks/ClientTweaks.java
@@ -28,6 +28,7 @@ public class ClientTweaks {
     private void setupClient(FMLClientSetupEvent event) {
         registerTweak(new AdditionalVolumeSlider("masterVolumeSlider", ClientTweaksConfig.CLIENT.masterVolumeSlider, SoundCategory.MASTER, 0));
         registerTweak(new AdditionalVolumeSlider("musicVolumeSlider", ClientTweaksConfig.CLIENT.musicVolumeSlider, SoundCategory.MUSIC, 160));
+        registerTweak(new NoOffhandTorchAtAll());
         registerTweak(new NoOffhandTorchWithBlock());
         registerTweak(new NoOffhandTorchWithEmptyHand());
         registerTweak(new OffhandTorchWithToolOnly());

--- a/src/main/java/net/blay09/mods/clienttweaks/ClientTweaksConfig.java
+++ b/src/main/java/net/blay09/mods/clienttweaks/ClientTweaksConfig.java
@@ -19,6 +19,7 @@ public class ClientTweaksConfig {
         public final ForgeConfigSpec.BooleanValue hideOffhandItem;
         public final ForgeConfigSpec.BooleanValue hideOwnParticleEffects;
         public final ForgeConfigSpec.BooleanValue hideShieldUnlessHoldingWeapon;
+        public final ForgeConfigSpec.BooleanValue noOffhandTorchAtAll;
         public final ForgeConfigSpec.BooleanValue noOffhandTorchWithBlock;
         public final ForgeConfigSpec.BooleanValue noOffhandTorchWithEmptyHand;
         public final ForgeConfigSpec.BooleanValue offhandTorchWithToolOnly;
@@ -65,6 +66,11 @@ public class ClientTweaksConfig {
                     .comment("This option will hide your shield unless you are holding a weapon.")
                     .translation("config.clienttweaks.hideShieldUnlessHoldingWeapon")
                     .define("hideShieldUnlessHoldingWeapon", true);
+
+            noOffhandTorchAtAll = builder
+                    .comment("This prevents torches from being placed from your offhand at all.")
+                    .translation("config.clienttweaks.noOffhandTorchAtAll")
+                    .define("noOffhandTorchAtAll", false);
 
             noOffhandTorchWithBlock = builder
                     .comment("This prevents torches from being placed from your offhand if you have a block in your main hand.")

--- a/src/main/java/net/blay09/mods/clienttweaks/tweak/NoOffhandTorchAtAll.java
+++ b/src/main/java/net/blay09/mods/clienttweaks/tweak/NoOffhandTorchAtAll.java
@@ -1,0 +1,34 @@
+package net.blay09.mods.clienttweaks.tweak;
+
+import net.blay09.mods.clienttweaks.ClientTweaksConfig;
+import net.minecraft.client.Minecraft;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.Hand;
+import net.minecraft.util.ResourceLocation;
+import net.minecraftforge.client.event.InputEvent;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
+
+public class NoOffhandTorchAtAll extends AbstractClientTweak {
+
+    public NoOffhandTorchAtAll() {
+        super("noOffhandTorchAtAll", ClientTweaksConfig.CLIENT.noOffhandTorchAtAll);
+    }
+
+    @SubscribeEvent
+    public void onRightClick(InputEvent.ClickInputEvent event) {
+        if (isEnabled() && event.isUseItem() && event.getHand() == Hand.OFF_HAND) {
+            Minecraft mc = Minecraft.getInstance();
+            ItemStack heldItem = mc.player != null ? mc.player.getHeldItem(event.getHand()) : ItemStack.EMPTY;
+            if (!heldItem.isEmpty()) {
+                ResourceLocation registryName = heldItem.getItem().getRegistryName();
+                if (registryName != null) {
+                    if (ClientTweaksConfig.CLIENT.torchItems.get().contains(registryName.toString())) {
+                        event.setSwingHand(false);
+                        event.setCanceled(true);
+                    }
+                }
+            }
+        }
+    }
+
+}


### PR DESCRIPTION
Personally, I'm using the offhand for exactly three things: torches, totem of undying or a shield. I don't want the offhand to place torches at all, no matter what amount of torches is left or what I'm holding in my main hand. So I've used NoOffhandTorchWithEmptyHand as a base for this and removed the part that checked if the main hand is empty, hopefully resulting in blocking torch placement from the offhand.