### PR TITLE
Add soul torches to torch items list

### DIFF
--- a/src/main/java/net/blay09/mods/clienttweaks/ClientTweaksConfig.java
+++ b/src/main/java/net/blay09/mods/clienttweaks/ClientTweaksConfig.java
@@ -109,6 +109,7 @@ public class ClientTweaksConfig {
                     .translation("clienttweaks.config.torchItems")
                     .defineList("torchItems", Lists.newArrayList(
                             "minecraft:torch",
+                            "minecraft:soul_torch",
                             "tconstruct:stone_torch"), it -> it instanceof String);
 
             torchTools = builder


### PR DESCRIPTION
Soul torches were added in 1.16

![Screenshot of soul torch in the creative tab](https://i.imgur.com/rsFOTQa.png)