### PR TITLE
fix guard shape early return so diagonal walls aren't misread

### DIFF
--- a/common/src/main/java/net/blay09/mods/clienttweaks/mixin/CrossCollisionBlockMixin.java
+++ b/common/src/main/java/net/blay09/mods/clienttweaks/mixin/CrossCollisionBlockMixin.java
@@ -1,68 +1,26 @@
 package net.blay09.mods.clienttweaks.mixin;
 
-import net.blay09.mods.clienttweaks.ClientTweaksConfig;
-import net.minecraft.client.Minecraft;
+import net.blay09.mods.clienttweaks.tweak.PaneBuildingSupport;
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.level.BlockGetter;
-import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.CrossCollisionBlock;
 import net.minecraft.world.level.block.state.BlockState;
-import net.minecraft.world.level.block.state.properties.Property;
-import net.minecraft.world.phys.AABB;
 import net.minecraft.world.phys.shapes.CollisionContext;
-import net.minecraft.world.phys.shapes.Shapes;
 import net.minecraft.world.phys.shapes.VoxelShape;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
-import java.util.Set;
-
 @Mixin(CrossCollisionBlock.class)
 public class CrossCollisionBlockMixin {
 
     @Inject(method = "getShape(Lnet/minecraft/world/level/block/state/BlockState;Lnet/minecraft/world/level/BlockGetter;Lnet/minecraft/core/BlockPos;Lnet/minecraft/world/phys/shapes/CollisionContext;)Lnet/minecraft/world/phys/shapes/VoxelShape;", at = @At("RETURN"), cancellable = true)
     void getShape(BlockState state, BlockGetter blockGetter, BlockPos pos, CollisionContext context, CallbackInfoReturnable<VoxelShape> callbackInfo) {
-        final var minecraft = Minecraft.getInstance();
-        @SuppressWarnings("ConstantValue") final var player = minecraft != null ? minecraft.player : null;
-        boolean isHoldingCrossCollisionBlock = player != null && Block.byItem(player.getMainHandItem().getItem()) instanceof CrossCollisionBlock;
-        if (isHoldingCrossCollisionBlock && ClientTweaksConfig.getActive().building.paneBuildingSupport) {
-            // Only touch block states built from the properties this logic understands; anything else
-            // (e.g. diagonal connectors adding extra directional properties) is left alone
-            if (!state.getProperties().containsAll(Set.<Property<?>>of(CrossCollisionBlock.NORTH, CrossCollisionBlock.EAST, CrossCollisionBlock.SOUTH, CrossCollisionBlock.WEST))
-                    || !Set.<Property<?>>of(CrossCollisionBlock.NORTH, CrossCollisionBlock.EAST, CrossCollisionBlock.SOUTH, CrossCollisionBlock.WEST, CrossCollisionBlock.WATERLOGGED).containsAll(state.getProperties())) {
-                return;
-            }
-
-            boolean isPillarSection = !state.getValue(CrossCollisionBlock.EAST) && !state.getValue(CrossCollisionBlock.WEST) && !state.getValue(
-                    CrossCollisionBlock.NORTH) && !state.getValue(CrossCollisionBlock.SOUTH);
-            boolean isThinSection = isOnlyOneTrue(state.getValue(CrossCollisionBlock.EAST),
-                    state.getValue(CrossCollisionBlock.WEST),
-                    state.getValue(CrossCollisionBlock.NORTH),
-                    state.getValue(CrossCollisionBlock.SOUTH));
-            if (isThinSection || isPillarSection) {
-                final var originalShape = callbackInfo.getReturnValue();
-                if (!originalShape.isEmpty()) {
-                    final var modifiedShape = Shapes.create(originalShape.bounds()
-                            .expandTowards(0.25, 0, 0.25)
-                            .expandTowards(-0.25, 0, -0.25)
-                            .intersect(new AABB(0.01, 0.01, 0.01, 0.99, 0.99, 0.99))
-                    );
-                    callbackInfo.setReturnValue(modifiedShape);
-                }
-            }
+        final var shape = PaneBuildingSupport.getShape(state, context, callbackInfo.getReturnValue());
+        if (shape != null) {
+            callbackInfo.setReturnValue(shape);
         }
-    }
-
-    private static boolean isOnlyOneTrue(boolean... args) {
-        int trues = 0;
-        for (boolean arg : args) {
-            if (arg) {
-                trues++;
-            }
-        }
-        return trues == 1;
     }
 
 }

--- a/common/src/main/java/net/blay09/mods/clienttweaks/mixin/CrossCollisionBlockMixin.java
+++ b/common/src/main/java/net/blay09/mods/clienttweaks/mixin/CrossCollisionBlockMixin.java
@@ -7,6 +7,7 @@ import net.minecraft.world.level.BlockGetter;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.CrossCollisionBlock;
 import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.level.block.state.properties.Property;
 import net.minecraft.world.phys.AABB;
 import net.minecraft.world.phys.shapes.CollisionContext;
 import net.minecraft.world.phys.shapes.Shapes;
@@ -15,6 +16,8 @@ import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+import java.util.Set;
 
 @Mixin(CrossCollisionBlock.class)
 public class CrossCollisionBlockMixin {
@@ -25,9 +28,10 @@ public class CrossCollisionBlockMixin {
         @SuppressWarnings("ConstantValue") final var player = minecraft != null ? minecraft.player : null;
         boolean isHoldingCrossCollisionBlock = player != null && Block.byItem(player.getMainHandItem().getItem()) instanceof CrossCollisionBlock;
         if (isHoldingCrossCollisionBlock && ClientTweaksConfig.getActive().building.paneBuildingSupport) {
-            // Exit out early if the block does not have the properties we use, to prevent crashes with mods that extend CrossCollisionBlock
-            if (!state.hasProperty(CrossCollisionBlock.EAST) || !state.hasProperty(CrossCollisionBlock.WEST) || !state.hasProperty(CrossCollisionBlock.NORTH) || !state.hasProperty(
-                    CrossCollisionBlock.SOUTH) || state.getProperties().size() > 6) {
+            // Only touch block states built from the properties this logic understands; anything else
+            // (e.g. diagonal connectors adding extra directional properties) is left alone
+            if (!state.getProperties().containsAll(Set.<Property<?>>of(CrossCollisionBlock.NORTH, CrossCollisionBlock.EAST, CrossCollisionBlock.SOUTH, CrossCollisionBlock.WEST))
+                    || !Set.<Property<?>>of(CrossCollisionBlock.NORTH, CrossCollisionBlock.EAST, CrossCollisionBlock.SOUTH, CrossCollisionBlock.WEST, CrossCollisionBlock.WATERLOGGED).containsAll(state.getProperties())) {
                 return;
             }
 

--- a/common/src/main/java/net/blay09/mods/clienttweaks/mixin/CrossCollisionBlockMixin.java
+++ b/common/src/main/java/net/blay09/mods/clienttweaks/mixin/CrossCollisionBlockMixin.java
@@ -27,7 +27,7 @@ public class CrossCollisionBlockMixin {
         if (isHoldingCrossCollisionBlock && ClientTweaksConfig.getActive().building.paneBuildingSupport) {
             // Exit out early if the block does not have the properties we use, to prevent crashes with mods that extend CrossCollisionBlock
             if (!state.hasProperty(CrossCollisionBlock.EAST) || !state.hasProperty(CrossCollisionBlock.WEST) || !state.hasProperty(CrossCollisionBlock.NORTH) || !state.hasProperty(
-                    CrossCollisionBlock.SOUTH)) {
+                    CrossCollisionBlock.SOUTH) || state.getProperties().size() > 6) {
                 return;
             }
 

--- a/common/src/main/java/net/blay09/mods/clienttweaks/tweak/PaneBuildingSupport.java
+++ b/common/src/main/java/net/blay09/mods/clienttweaks/tweak/PaneBuildingSupport.java
@@ -1,0 +1,59 @@
+package net.blay09.mods.clienttweaks.tweak;
+
+import net.blay09.mods.clienttweaks.ClientTweaksConfig;
+import net.minecraft.client.Minecraft;
+import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.CrossCollisionBlock;
+import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.phys.AABB;
+import net.minecraft.world.phys.shapes.CollisionContext;
+import net.minecraft.world.phys.shapes.EntityCollisionContext;
+import net.minecraft.world.phys.shapes.Shapes;
+import net.minecraft.world.phys.shapes.VoxelShape;
+import org.jetbrains.annotations.Nullable;
+
+public class PaneBuildingSupport {
+
+    @Nullable
+    public static VoxelShape getShape(BlockState state, CollisionContext context, VoxelShape originalShape) {
+        final var minecraft = Minecraft.getInstance();
+        @SuppressWarnings("ConstantValue") final var player = minecraft != null ? minecraft.player : null;
+        final var isHoldingCrossCollisionBlock = player != null && Block.byItem(player.getMainHandItem().getItem()) instanceof CrossCollisionBlock;
+        final var isPlayerShapeQuery = context instanceof EntityCollisionContext entityCollisionContext && entityCollisionContext.getEntity() == player;
+        if (!isPlayerShapeQuery || !isHoldingCrossCollisionBlock || !ClientTweaksConfig.getActive().building.paneBuildingSupport) {
+            return null;
+        }
+
+        if (!isSupported(state) || !isPillar(state) || originalShape.isEmpty()) {
+            return null;
+        }
+
+        return Shapes.create(originalShape.bounds()
+                .expandTowards(0.25, 0, 0.25)
+                .expandTowards(-0.25, 0, -0.25)
+                .intersect(new AABB(0.01, 0.01, 0.01, 0.99, 0.99, 0.99))
+        );
+    }
+
+    private static boolean isSupported(BlockState state) {
+        final var properties = state.getProperties();
+        if (!properties.contains(CrossCollisionBlock.NORTH)
+                || !properties.contains(CrossCollisionBlock.EAST)
+                || !properties.contains(CrossCollisionBlock.SOUTH)
+                || !properties.contains(CrossCollisionBlock.WEST)) {
+            return false;
+        }
+
+        return properties.size() == 4 || properties.size() == 5 && properties.contains(CrossCollisionBlock.WATERLOGGED);
+    }
+
+    private static boolean isPillar(BlockState state) {
+        final var east = state.getValue(CrossCollisionBlock.EAST);
+        final var west = state.getValue(CrossCollisionBlock.WEST);
+        final var north = state.getValue(CrossCollisionBlock.NORTH);
+        final var south = state.getValue(CrossCollisionBlock.SOUTH);
+        final var connections = (east ? 1 : 0) + (west ? 1 : 0) + (north ? 1 : 0) + (south ? 1 : 0);
+        return connections <= 1;
+    }
+
+}


### PR DESCRIPTION
placing a diagonal wall from Fuzs' Diagonal Walls would make the block underneath it lose its top face and render invisible. Traced it back to this mixin.

`getShape()` decides a state is an isolated pillar/thin section just by checking if NORTH/EAST/SOUTH/WEST are all false, then swaps in a bigger placeholder shape for building support. A column-less diagonal wall connector has all four of those false too, but it's still connected via diagonal properties this mixin doesn't check, so it gets misclassified as a lone post and handed a shape way bigger than it should be.

ModernFix caches `getShape()` per BlockState to avoid rebuilding it constantly. If that cache gets populated for the first time right as you place the wall the oversized shape gets baked in permanently, and the block below starts getting its face culled. Only a full world rejoin fixes it, since nothing else invalidates that cache.

Fix: bail out if the state has more properties than the biggest shape this code actually understands (if I've read the code correctly that been said) (UP + WATERLOGGED + 4 directional = 6, covers fences/panes at 5 and walls at 6). 

Tested with Diagonal Walls + ModernFix + this mod together

<img width="934" height="554" src="https://github.com/user-attachments/assets/52f3e5ed-e442-4809-b088-6b13b769eeb6" />
<img width="554" height="853" src="https://github.com/user-attachments/assets/0a818e76-168d-4758-b462-3c1226821a22" />

